### PR TITLE
1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,11 @@ python:
   - '3.6'
 install: pip install .
 script: python setup.py test
+deploy:
+  on:
+    branch: master
+  provider: pypi
+  distributions: sdist bdist_wheel
+  user: efl_phx
+  password:
+    secure: aZx2Op+s+bGY+EsRbJO6PuluVu0g4/KE2Y9BkD9XajRDASoyUt0pWzUNU7FhvLkfPu0LmnzHgGPRMgeVzLMhxiSF/trAyWTnxSe+wQoVrhyV86uiiwBuyJfQrwbfRi61eKzi0m+j0douuBOSRbT8YSg38L9qYMzBFn6TsKZjQlAxOCSxlhfS/Q5I5+n+5aj4ZHCTXfNSZh5MnVFVT9ZJny9y23P4rYkgZb1eeXwUJJBHdfPQHkwNRmotP4cKiqZt1+SrFWqmwfnasIuv+EgZZ4vs7bPdfhH2x0lT4fBIAdV9SpyaqXOdH3VLWQ5U2IeBHNYYPHuQDjZS1VX0sZfON1GMCPkEC14RUpv8FaJzvIpW4KG95dBjGf9HPiFQm4YpWrkExc0u97yCrzwrGur+Z6plJozDk8d1GM9h8EDhSvKPhbWnJvH7kc8bUqqDFH1ZtIqB6pA4i36fNqOx+yM4B2zVvU1hi6LBSayatW3JXYfYT8QbtM319WU2yvtM85GptmeFRcfbOGa5SYJqFrj30MjemCwD7m4LjH8kPP/15vK7Eo96aJe5dXH3p7uwYQ0JVpoQGupvghJCAiW7c6dLY+SYH9l7ybQKbAHomXUi9F9hD1sQxuQRA/N0O819CQpA7IslAKsBBpgoe4Nd3bqhzb0D+pxAsMldFQYsOEThMnw=

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     long_description = long_description,
 
     install_requires = [
-        'filters',
+        'filters >= 1.2.0',
         'iso3166',
         'language_tags',
         'py-moneyed',

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,6 @@ with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f: # type: StreamReader
 
 
 ##
-# Certain dependencies are optional depending on Python version.
-dependencies = [
-    'filters',
-    'iso3166',
-    'language_tags',
-    'py-moneyed',
-]
-
-
-##
 # Off we go!
 setup(
     name        = 'filters-iso',
@@ -46,7 +36,12 @@ setup(
 
     long_description = long_description,
 
-    install_requires = dependencies,
+    install_requires = [
+        'filters',
+        'iso3166',
+        'language_tags',
+        'py-moneyed',
+    ],
 
     test_suite    = 'test',
     test_loader   = 'nose.loader:TestLoader',


### PR DESCRIPTION
ISO Filters v1.0.0
Initial release.  Same functionality as the `filters.iso` package from [Filters v1.1.7](https://github.com/eflglobal/filters/releases/tag/1.1.7), but now installed as an extension package.

**Important:** If you were previously using ISO Filters, note that they are now part of the Extensions framework, so you will need to update your code slightly:

```python
# Before
import filters as f
f.Country().apply('pe')

# After; note `f.ext`.
import filters as f
f.ext.Country().apply('pe')
```